### PR TITLE
feat: add hashSeed config in babel-plugin-react-scoped-css plugin

### DIFF
--- a/packages/babel-plugin-react-scoped-css/__snapshots__/index.spec.js.snap
+++ b/packages/babel-plugin-react-scoped-css/__snapshots__/index.spec.js.snap
@@ -2,15 +2,15 @@
 
 exports[`babel-plugin-react-scoped-css frag.jsx 1`] = `
 "import React from 'react';
-import \\"./frag.scoped.css?scopeId=d0f0b5fc\\";
+import \\"./frag.scoped.css?scopeId=f2245a65\\";
 
 const Frag = () => {
-  return <div data-v-d0f0b5fc={\\"\\"}>
+  return <div data-v-f2245a65={\\"\\"}>
       <React.Fragment>
-        <div className=\\"test-frag\\" data-v-d0f0b5fc={\\"\\"}></div>
+        <div className=\\"test-frag\\" data-v-f2245a65={\\"\\"}></div>
       </React.Fragment>
       <>
-        <div data-v-d0f0b5fc={\\"\\"}>text</div>
+        <div data-v-f2245a65={\\"\\"}>text</div>
       </>
     </div>;
 };
@@ -21,7 +21,7 @@ export default Frag;"
 exports[`babel-plugin-react-scoped-css from-example.jsx 1`] = `
 "import React from 'react';
 import styled from 'styled-components';
-import styles from \\"./Content.scoped.scss?scopeId=fa0f6685\\";
+import styles from \\"./Content.scoped.scss?scopeId=81d995ea\\";
 import Grid from './Grid';
 import GridForwardProps from './GridForwardProps';
 const Text = styled.div\`
@@ -29,30 +29,30 @@ const Text = styled.div\`
 \`;
 
 const FromExample = props => {
-  return <div className=\\"content\\" data-v-fa0f6685={\\"\\"}>
-      <h3 data-v-fa0f6685={\\"\\"}>Styling html tags</h3>
-      <p data-v-fa0f6685={\\"\\"}>p tag with style</p>
+  return <div className=\\"content\\" data-v-81d995ea={\\"\\"}>
+      <h3 data-v-81d995ea={\\"\\"}>Styling html tags</h3>
+      <p data-v-81d995ea={\\"\\"}>p tag with style</p>
 
       <React.Fragment>
-        <div data-v-fa0f6685={\\"\\"}>
-          <p data-v-fa0f6685={\\"\\"}>content wrapped with React Fragment should be fine</p>
+        <div data-v-81d995ea={\\"\\"}>
+          <p data-v-81d995ea={\\"\\"}>content wrapped with React Fragment should be fine</p>
         </div>
       </React.Fragment>
 
-      <h3 data-v-fa0f6685={\\"\\"}>Using classes</h3>
-      <div className=\\"grid\\" data-v-fa0f6685={\\"\\"} />
-      <div className=\\"grid\\" data-v-fa0f6685={\\"\\"} />
+      <h3 data-v-81d995ea={\\"\\"}>Using classes</h3>
+      <div className=\\"grid\\" data-v-81d995ea={\\"\\"} />
+      <div className=\\"grid\\" data-v-81d995ea={\\"\\"} />
 
-      <h3 data-v-fa0f6685={\\"\\"}>Styling child components with css modules</h3>
-      <Grid className={styles.grid} data-v-fa0f6685={\\"\\"} />
-      <Grid className={styles.grid} data-v-fa0f6685={\\"\\"} />
+      <h3 data-v-81d995ea={\\"\\"}>Styling child components with css modules</h3>
+      <Grid className={styles.grid} data-v-81d995ea={\\"\\"} />
+      <Grid className={styles.grid} data-v-81d995ea={\\"\\"} />
 
-      <h3 data-v-fa0f6685={\\"\\"}>Styling child components which forward data-v attributes to its root element</h3>
-      <GridForwardProps className=\\"content-grid\\" data-v-fa0f6685={\\"\\"} />
-      <GridForwardProps className=\\"content-grid\\" data-v-fa0f6685={\\"\\"} />
+      <h3 data-v-81d995ea={\\"\\"}>Styling child components which forward data-v attributes to its root element</h3>
+      <GridForwardProps className=\\"content-grid\\" data-v-81d995ea={\\"\\"} />
+      <GridForwardProps className=\\"content-grid\\" data-v-81d995ea={\\"\\"} />
 
-      <h3 data-v-fa0f6685={\\"\\"}>Styling with styled-components</h3>
-      <Text className=\\"text\\" data-v-fa0f6685={\\"\\"}>Some content in styled-components</Text>
+      <h3 data-v-81d995ea={\\"\\"}>Styling with styled-components</h3>
+      <Text className=\\"text\\" data-v-81d995ea={\\"\\"}>Some content in styled-components</Text>
     </div>;
 };
 

--- a/packages/babel-plugin-react-scoped-css/__snapshots__/index.spec.js.snap
+++ b/packages/babel-plugin-react-scoped-css/__snapshots__/index.spec.js.snap
@@ -2,15 +2,15 @@
 
 exports[`babel-plugin-react-scoped-css frag.jsx 1`] = `
 "import React from 'react';
-import \\"./frag.scoped.css?scopeId=397851dd\\";
+import \\"./frag.scoped.css?scopeId=d0f0b5fc\\";
 
 const Frag = () => {
-  return <div data-v-397851dd={\\"\\"}>
+  return <div data-v-d0f0b5fc={\\"\\"}>
       <React.Fragment>
-        <div className=\\"test-frag\\" data-v-397851dd={\\"\\"}></div>
+        <div className=\\"test-frag\\" data-v-d0f0b5fc={\\"\\"}></div>
       </React.Fragment>
       <>
-        <div data-v-397851dd={\\"\\"}>text</div>
+        <div data-v-d0f0b5fc={\\"\\"}>text</div>
       </>
     </div>;
 };
@@ -21,7 +21,7 @@ export default Frag;"
 exports[`babel-plugin-react-scoped-css from-example.jsx 1`] = `
 "import React from 'react';
 import styled from 'styled-components';
-import styles from \\"./Content.scoped.scss?scopeId=ac9feed2\\";
+import styles from \\"./Content.scoped.scss?scopeId=fa0f6685\\";
 import Grid from './Grid';
 import GridForwardProps from './GridForwardProps';
 const Text = styled.div\`
@@ -29,30 +29,30 @@ const Text = styled.div\`
 \`;
 
 const FromExample = props => {
-  return <div className=\\"content\\" data-v-ac9feed2={\\"\\"}>
-      <h3 data-v-ac9feed2={\\"\\"}>Styling html tags</h3>
-      <p data-v-ac9feed2={\\"\\"}>p tag with style</p>
+  return <div className=\\"content\\" data-v-fa0f6685={\\"\\"}>
+      <h3 data-v-fa0f6685={\\"\\"}>Styling html tags</h3>
+      <p data-v-fa0f6685={\\"\\"}>p tag with style</p>
 
       <React.Fragment>
-        <div data-v-ac9feed2={\\"\\"}>
-          <p data-v-ac9feed2={\\"\\"}>content wrapped with React Fragment should be fine</p>
+        <div data-v-fa0f6685={\\"\\"}>
+          <p data-v-fa0f6685={\\"\\"}>content wrapped with React Fragment should be fine</p>
         </div>
       </React.Fragment>
 
-      <h3 data-v-ac9feed2={\\"\\"}>Using classes</h3>
-      <div className=\\"grid\\" data-v-ac9feed2={\\"\\"} />
-      <div className=\\"grid\\" data-v-ac9feed2={\\"\\"} />
+      <h3 data-v-fa0f6685={\\"\\"}>Using classes</h3>
+      <div className=\\"grid\\" data-v-fa0f6685={\\"\\"} />
+      <div className=\\"grid\\" data-v-fa0f6685={\\"\\"} />
 
-      <h3 data-v-ac9feed2={\\"\\"}>Styling child components with css modules</h3>
-      <Grid className={styles.grid} data-v-ac9feed2={\\"\\"} />
-      <Grid className={styles.grid} data-v-ac9feed2={\\"\\"} />
+      <h3 data-v-fa0f6685={\\"\\"}>Styling child components with css modules</h3>
+      <Grid className={styles.grid} data-v-fa0f6685={\\"\\"} />
+      <Grid className={styles.grid} data-v-fa0f6685={\\"\\"} />
 
-      <h3 data-v-ac9feed2={\\"\\"}>Styling child components which forward data-v attributes to its root element</h3>
-      <GridForwardProps className=\\"content-grid\\" data-v-ac9feed2={\\"\\"} />
-      <GridForwardProps className=\\"content-grid\\" data-v-ac9feed2={\\"\\"} />
+      <h3 data-v-fa0f6685={\\"\\"}>Styling child components which forward data-v attributes to its root element</h3>
+      <GridForwardProps className=\\"content-grid\\" data-v-fa0f6685={\\"\\"} />
+      <GridForwardProps className=\\"content-grid\\" data-v-fa0f6685={\\"\\"} />
 
-      <h3 data-v-ac9feed2={\\"\\"}>Styling with styled-components</h3>
-      <Text className=\\"text\\" data-v-ac9feed2={\\"\\"}>Some content in styled-components</Text>
+      <h3 data-v-fa0f6685={\\"\\"}>Styling with styled-components</h3>
+      <Text className=\\"text\\" data-v-fa0f6685={\\"\\"}>Some content in styled-components</Text>
     </div>;
 };
 

--- a/packages/babel-plugin-react-scoped-css/index.js
+++ b/packages/babel-plugin-react-scoped-css/index.js
@@ -25,8 +25,7 @@ module.exports = function({ types: t }) {
       return computedHash[filePath]
     }
 
-    const filename = getFilenameFromPath(filePath)
-    const hash = md5(filename + lastHash).substr(0, 8)
+    const hash = md5(filePath + lastHash).substr(0, 8)
     computedHash[filePath] = hash
     lastHash = hash
     return hash

--- a/packages/babel-plugin-react-scoped-css/index.js
+++ b/packages/babel-plugin-react-scoped-css/index.js
@@ -26,9 +26,8 @@ module.exports = function({ types: t }) {
       return computedHash[filePath]
     }
 
-    const filename = getFilenameFromPath(filePath)
     const relative = path.relative(process.cwd(),filePath)
-    const hash = md5(hashSeed + relative + filename + lastHash).substr(0, 8)
+    const hash = md5(hashSeed + relative + lastHash).substr(0, 8)
     computedHash[filePath] = hash
     lastHash = hash
     return hash

--- a/packages/babel-plugin-react-scoped-css/index.spec.js
+++ b/packages/babel-plugin-react-scoped-css/index.spec.js
@@ -23,7 +23,11 @@ describe('babel-plugin-react-scoped-css', () => {
         encoding: 'utf8',
       })
       const { code } = babel.transform(codeContent, {
-        plugins: [plugin],
+        plugins: [[
+          plugin,{
+            hashSeed : 'userSeed'
+          }
+        ]],
         filename: fixture.filename,
       })
       expect(code).toMatchSnapshot()


### PR DESCRIPTION
Thank you for your plugin.
When I use this plugin in multiple projects(pubish as npm),I found the same file name in different projects `data-v-md5(filename)` is conflicted.
So I provide a MR with filePath to md5 ，to avoid this situation.