### PR TITLE
fix: Hash code is diffrent in asynchronous tasks

### DIFF
--- a/packages/babel-plugin-react-scoped-css/index.js
+++ b/packages/babel-plugin-react-scoped-css/index.js
@@ -17,8 +17,8 @@ const forPlugin = (path, stats) => {
   return filename.match(new RegExp(includeRegExp))
 }
 
+const computedHash = {}
 module.exports = function({ types: t }) {
-  const computedHash = {}
   let lastHash = ''
 
   const computeHash = (hashSeed = '', filePath) => {


### PR DESCRIPTION
您好我们有工程上有这样一个能力，就是把JS编译为ES6版本和ES5版本，这两个webpack的任务是异步进的，并且这两个任务都用到`babel-plugin-react-scoped-css`的能力。这样的打2个版本的目的是针对不同的系统机型，用户可以加载不同兼容性的JS资源。
因为这ES6和ES5的任务是异步的关系，目前在使用`babel-plugin-react-scoped-css`的过程中遇到一个问题，我在代码中加入了下面这段调试日志

```javascript
  const computeHash = (hashSeed = '', filePath) => {
    // console.log('computedHash',computedHash)
    if (computedHash[filePath]) {
      return computedHash[filePath]
    }


    const relative = path.relative(process.cwd(), filePath)
    const hash = md5(hashSeed + relative + lastHash).substr(0, 8)
    console.log('==========')
    console.log('relative',relative)
    console.log('hash',hash)
    console.log('==========')
    computedHash[filePath] = hash
    lastHash = hash
    return hash
  }
```

运行结果是：
```bin
  building ======                                                       10% 0.2s==========
relative src/mobile/index.tsx
hash 2d612fc9
==========
==========
relative src/mobile/index.tsx
hash 2d612fc9
==========
  building =======                                                      11% 6.0s==========
relative src/components/main/index.tsx
hash b4a22c79
==========
  building =======                                                      11% 6.4s==========
relative src/components/error/index.tsx
hash 1004f9d7
==========
  building =======                                                      11% 6.5s==========
relative src/components/end/index.tsx
hash d82ef12a
==========
  building =======                                                      11% 6.6s==========
relative src/components/end/index.tsx
hash 8b7a57b8
==========
  building =======                                                      11% 6.6s==========
relative src/components/main/index.tsx
hash 3ccc63af
==========
  building =======                                                      11% 7.1s==========
relative src/components/error/index.tsx
hash 33c4dec2
==========
```

发现`src/components/error/index.tsx`虽然都是这个文件路径，但是生成的hash值是不一样的。而引起这个问题的原因在于

```javascript
module.exports = function({ types: t }) {
  const computedHash = {} //两个任务拿到的这个值的内存状态不一致
  let lastHash = ''

  const computeHash = (hashSeed = '', filePath) => {
    console.log('computedHash',computedHash)
    if (computedHash[filePath]) {
      return computedHash[filePath]
    }
    //
  }
}
```
因此上面的代码会看到两个任务的执行时打出了下面这样的日志：
```
computedHash {
  '/Users/ginko/WorkSpace/alibaba/yishun-demos/2021-spring-festival-main/src/mobile/index.tsx': '2d612fc9',
  '/Users/ginko/WorkSpace/alibaba/yishun-demos/2021-spring-festival-main/src/components/error/index.tsx': 'aba41ff9'
}
computedHash {
  '/Users/ginko/WorkSpace/alibaba/yishun-demos/2021-spring-festival-main/src/mobile/index.tsx': '2d612fc9'
}
```

因此我的修改办法是将`computedHash`放到外部变成一个全局变量，这样两个任务的内存状态就是一致的，并且保证了异步任务的hash也是一致的，这样就能只编译一份可以共享的CSS文件即可。所以麻烦您看下这个pr是否可以发一个版本。
