### PR TITLE
Fix react fragment

### DIFF
--- a/packages/babel-plugin-react-scoped-css/README.md
+++ b/packages/babel-plugin-react-scoped-css/README.md
@@ -99,6 +99,16 @@ also note that you can define your own matching rule like this
 If you have other plugins installed, just add it to the list, order doesn't matter.
 
 Note: this plugin accepts `include`(RegExp, which defaults to `/\.scoped\.(sa|sc|c)ss$/`) to config which css file to be identified as scoped.
+Note: this plugin accepts `ignoreNode` to config which Node to be ignore. eg React.Fragment config 
+```js
+const ignoreNode = (node) => {
+    if(node.openingElement.name.name === 'Fragment') return true;
+    if(node.openingElement.name.type === 'JSXMemberExpression' 
+      && node.openingElement.name.object.name === 'React'
+      && node.openingElement.name.property.name === 'Fragment' )  return true;
+    return false;
+};
+``` 
 
 **the webpack loader**
 

--- a/packages/babel-plugin-react-scoped-css/index.js
+++ b/packages/babel-plugin-react-scoped-css/index.js
@@ -49,9 +49,12 @@ module.exports = function ({ types: t }) {
         path.node.source.value = `${path.node.source.value}?scopeId=${hash}`;
       },
       JSXElement(path, stats) {
+        const { ignoreNode } = stats.opts;
+        // ignoreNode 可以让用户自定义哪些节点不添加约束，比如 React.Fragment 添加额外属性会报warn或error
         if (
           !this.hasScopedCss ||
-          path.node.openingElement.name.type === "JSXMemberExpression"
+          (typeof ignoreNode === 'function' ? ignoreNode(path.node, stats) : path.node.openingElement.name.type === "JSXMemberExpression")
+          
         ) {
           return;
         }


### PR DESCRIPTION
当前BUG：遇到如下写法任然会被加上data-v-id，而React.Fragment是不能被加额外熟悉，不然会报如下错误：Warning: Invalid prop `data-v-d75c71aa` supplied to `React.Fragment`. React.Fragment can only have `key` and `children` props.

解决方案：添加 ignoreNode 插件属性，传入函数，可自定义无需处理的节点，返回true则表示无需处理。然后在如下代码加入此逻辑，完全向下兼容。如需处理完整React.Fragment，参考README文档 ignoreNode  属性
![image](https://github.com/gaoxiaoliangz/react-scoped-css/assets/20812348/e9eabef5-20f4-4104-8c34-be35c925dc82)
